### PR TITLE
Install user logical delete

### DIFF
--- a/app/controllers/public/devise/confirmations_controller.rb
+++ b/app/controllers/public/devise/confirmations_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Public::Devise::ConfirmationsController < Devise::ConfirmationsController
+  # GET /resource/confirmation/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/confirmation
+  # def create
+  #   super
+  # end
+
+  # GET /resource/confirmation?confirmation_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after resending confirmation instructions.
+  # def after_resending_confirmation_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+
+  # The path used after confirmation.
+  # def after_confirmation_path_for(resource_name, resource)
+  #   super(resource_name, resource)
+  # end
+end

--- a/app/controllers/public/devise/omniauth_callbacks_controller.rb
+++ b/app/controllers/public/devise/omniauth_callbacks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Public::Devise::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  # You should configure your model like this:
+  # devise :omniauthable, omniauth_providers: [:twitter]
+
+  # You should also create an action method in this controller like this:
+  # def twitter
+  # end
+
+  # More info at:
+  # https://github.com/heartcombo/devise#omniauth
+
+  # GET|POST /resource/auth/twitter
+  # def passthru
+  #   super
+  # end
+
+  # GET|POST /users/auth/twitter/callback
+  # def failure
+  #   super
+  # end
+
+  # protected
+
+  # The path used when OmniAuth fails
+  # def after_omniauth_failure_path_for(scope)
+  #   super(scope)
+  # end
+end

--- a/app/controllers/public/devise/passwords_controller.rb
+++ b/app/controllers/public/devise/passwords_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Public::Devise::PasswordsController < Devise::PasswordsController
+  # GET /resource/password/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/password
+  # def create
+  #   super
+  # end
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource/password
+  # def update
+  #   super
+  # end
+
+  # protected
+
+  # def after_resetting_password_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sending reset password instructions
+  # def after_sending_reset_password_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+end

--- a/app/controllers/public/devise/registrations_controller.rb
+++ b/app/controllers/public/devise/registrations_controller.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+class Public::Devise::RegistrationsController < Devise::RegistrationsController
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /resource
+  # def create
+  #   super
+  # end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/public/devise/sessions_controller.rb
+++ b/app/controllers/public/devise/sessions_controller.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class Public::Devise::SessionsController < Devise::SessionsController
+  # before_action :configure_sign_in_params, only: [:create]
+
+  # GET /resource/sign_in
+  # def new
+  #   super
+  # end
+
+  # POST /resource/sign_in
+  # def create
+  #   super
+  # end
+
+  # DELETE /resource/sign_out
+  # def destroy
+  #   super
+  # end
+
+  before_action :reject_user, only: [:create] #ログイン時に退会済みユーザか判定
+
+  protected
+    def reject_user
+      @user = User.find_by(email: params[:user][:email].downcase)
+      if @user
+        if (@user.valid_password?(params[:user][:password]) && (@user.active_for_authentication? == false)) #パスワードは合っているが退会済みのとき
+          flash[:error] = "退会済みのユーザーです。"
+          redirect_to new_user_session_path
+        end
+      else
+        flash[:error] = "必須項目を入力してください。"
+      end
+    end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_in_params
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+  # end
+end

--- a/app/controllers/public/devise/sessions_controller.rb
+++ b/app/controllers/public/devise/sessions_controller.rb
@@ -24,12 +24,12 @@ class Public::Devise::SessionsController < Devise::SessionsController
     def reject_user
       @user = User.find_by(email: params[:user][:email].downcase)
       if @user
-        if (@user.valid_password?(params[:user][:password]) && (@user.active_for_authentication? == false)) #パスワードは合っているが退会済みのとき
-          flash[:error] = "退会済みのユーザーです。"
+        if @user.active_for_authentication? == false #退会済みのとき
+          flash[:notice] = '退会済みのユーザーです'
           redirect_to new_user_session_path
         end
       else
-        flash[:error] = "必須項目を入力してください。"
+        flash[:notice] = "必須項目を入力してください。"
       end
     end
 

--- a/app/controllers/public/devise/unlocks_controller.rb
+++ b/app/controllers/public/devise/unlocks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Public::Devise::UnlocksController < Devise::UnlocksController
+  # GET /resource/unlock/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/unlock
+  # def create
+  #   super
+  # end
+
+  # GET /resource/unlock?unlock_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after sending unlock password instructions
+  # def after_sending_unlock_instructions_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after unlocking the resource
+  # def after_unlock_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/public/favorites_controller.rb
+++ b/app/controllers/public/favorites_controller.rb
@@ -18,7 +18,7 @@ class Public::FavoritesController < ApplicationController
     @user = User.find(params[:id])
     @posts = @user.posts
 
-    favorites = Favorite.where(user_id: current_user.id).pluck(:post_id)  # ログイン中のユーザーのお気に入りのpost_idカラムを取得
+    favorites = Favorite.where(user_id: params[:id]).pluck(:post_id)  # ユーザーのお気に入りのpost_idカラムを取得
     @favorites = Post.find(favorites) # postsテーブルから、お気に入り登録済みのレコードを取得
   end
 

--- a/app/controllers/public/posts_controller.rb
+++ b/app/controllers/public/posts_controller.rb
@@ -5,8 +5,8 @@ class Public::PostsController < ApplicationController
   end
 
   def date_index #特定日の全投稿一覧
-    @posts = Post.where(date: params[:date])
     @date = params[:date]
+    @posts = Post.where(date: @date).where("(is_private = ?) OR (user_id == ?)", false, current_user)
   end
 
   def create
@@ -28,11 +28,9 @@ class Public::PostsController < ApplicationController
 
   def show
     @post = Post.find(params[:id])
-
-
     if @post.is_private == true && @post.user != current_user
       respond_to do |format|
-        format.html { redirect_to posts_path, notice: 'この記念日は非公開です' }
+        format.html { redirect_to root_path, notice: 'この記念日は非公開です' }
       end
     end
 

--- a/app/controllers/public/users_controller.rb
+++ b/app/controllers/public/users_controller.rb
@@ -3,6 +3,11 @@ class Public::UsersController < ApplicationController
   def show
     @user = User.find(params[:id])
     @posts = @user.posts.all
+    if @user.is_active == false
+      respond_to do |format|
+        format.html { redirect_to root_path, notice: '退会済みのユーザーです' }
+      end
+    end
   end
 
   def edit
@@ -15,9 +20,11 @@ class Public::UsersController < ApplicationController
     redirect_to user_path(@user.id)
   end
 
-  def deactivate
+  def deactivate #退会処理
     @user = User.find(params[:id])
+    @posts = @user.posts.all
     @user.update(is_active: false) #退会フラグを立てる
+    @posts.update(is_private: true) #投稿を全て非公開にする
     reset_session #ログアウトさせる
     redirect_to root_path #ホームにリダイレクト
   end

--- a/app/controllers/public/users_controller.rb
+++ b/app/controllers/public/users_controller.rb
@@ -15,6 +15,13 @@ class Public::UsersController < ApplicationController
     redirect_to user_path(@user.id)
   end
 
+  def deactivate
+    @user = User.find(params[:id])
+    @user.update(is_active: false) #退会フラグを立てる
+    reset_session #ログアウトさせる
+    redirect_to root_path #ホームにリダイレクト
+  end
+
   private
   def user_params
     params.require(:user).permit(:user_name, :introduction, :profile_image)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,12 @@ class User < ApplicationRecord
   has_many :favorites, dependent: :destroy
 
   attachment :profile_image
-  
+
   validates :user_name, presence: true
+
+  #退会済みユーザかどうかを判別、退会済みならfalseを返す
+  def active_for_authentication?
+    super && (self.is_active == true)
+  end
 
 end

--- a/app/views/homes/top.html.erb
+++ b/app/views/homes/top.html.erb
@@ -1,4 +1,5 @@
 <h1>Hello World</h1>
+<%= flash[:notice] %>
 <%= month_calendar do |date| %>
   <%= date %>
 <% end %>

--- a/app/views/public/users/edit.html.erb
+++ b/app/views/public/users/edit.html.erb
@@ -14,3 +14,8 @@
 <% end %>
 
 <%= link_to "戻る", user_path(@user.id) %>
+
+<%# 退会ボタン、念の為再度ログイン認証 %>
+<% if user_signed_in? && @user.id == current_user.id %>
+  <%= link_to "退会する", users_deactivate_path(current_user), method: :put, "data-confirm" => "本当に退会しますか？", class: "btn btn-outline-danger" %>
+<% end %>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,5 +1,6 @@
 <h2>ログイン</h2>
 
+<div><%= flash[:error] %></div>
 <%= form_with model: @user, url: user_session_path, local: true do |f| %>
   <div class="field">
     <%= f.label :email %><br />
@@ -7,19 +8,19 @@
   </div>
 
   <div class="field">
-    <%= f.label :password %><br />
+    <%= f.label :"パスワード" %><br />
     <%= f.password_field :password, autocomplete: "current-password" %>
   </div>
 
   <% if devise_mapping.rememberable? %>
     <div class="field">
       <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
+      <%= f.label :"ログイン状態を保存する" %>
     </div>
   <% end %>
 
   <div class="actions">
-    <%= f.submit "Log in" %>
+    <%= f.submit "ログイン" %>
   </div>
 <% end %>
 

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,6 +1,6 @@
 <h2>ログイン</h2>
 
-<div><%= flash[:error] %></div>
+<%= flash[:notice] %>
 <%= form_with model: @user, url: user_session_path, local: true do |f| %>
   <div class="field">
     <%= f.label :email %><br />

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -1,13 +1,13 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
+  <%= link_to "ログイン", new_session_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+  <%= link_to "新規登録", new_registration_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+  <%= link_to "パスワードを忘れた方", new_password_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,65 @@
+# Additional translations at https://github.com/heartcombo/devise/wiki/I18n
+
+ja:
+  devise:
+    confirmations:
+      confirmed: "Your email address has been successfully confirmed."
+      send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
+    failure:
+      already_authenticated: "You are already signed in."
+      inactive: "Your account is not activated yet."
+      invalid: "Invalid %{authentication_keys} or password."
+      locked: "Your account is locked."
+      last_attempt: "You have one more attempt before your account is locked."
+      not_found_in_database: "Invalid %{authentication_keys} or password."
+      timeout: "Your session expired. Please sign in again to continue."
+      unauthenticated: "You need to sign in or sign up before continuing."
+      unconfirmed: "You have to confirm your email address before continuing."
+    mailer:
+      confirmation_instructions:
+        subject: "Confirmation instructions"
+      reset_password_instructions:
+        subject: "Reset password instructions"
+      unlock_instructions:
+        subject: "Unlock instructions"
+      email_changed:
+        subject: "Email Changed"
+      password_change:
+        subject: "Password Changed"
+    omniauth_callbacks:
+      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
+      success: "Successfully authenticated from %{kind} account."
+    passwords:
+      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
+      send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
+      updated: "Your password has been changed successfully. You are now signed in."
+      updated_not_active: "Your password has been changed successfully."
+    registrations:
+      destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
+      signed_up: "Welcome! You have signed up successfully."
+      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
+      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
+      signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
+      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirmation link to confirm your new email address."
+      updated: "Your account has been updated successfully."
+      updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again."
+    sessions:
+      signed_in: "正常にログインしました"
+      signed_out: "ログアウトしました"
+      already_signed_out: "Signed out successfully."
+    unlocks:
+      send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
+      send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
+      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+  errors:
+    messages:
+      already_confirmed: "was already confirmed, please try signing in"
+      confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
+      expired: "has expired, please request a new one"
+      not_found: "not found"
+      not_locked: "was not locked"
+      not_saved:
+        one: "1 error prohibited this %{resource} from being saved:"
+        other: "%{count} errors prohibited this %{resource} from being saved:"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   #エンドユーザ
   scope module: :public do
     resources :users, only: [:show, :edit, :update]
+    put "/users/:id/deactivate" => "users#deactivate", as: 'users_deactivate'
     resources :posts do
       resource :favorites, only: [:create, :destroy]
     end


### PR DESCRIPTION
・ユーザ退会機能（論理削除）を実装
　- 退会済みユーザはログインできない（エラーメッセージは表示されない、要改善）
　- 退会済みユーザのプロフィールにアクセスしようとするとホームにリダイレクト
　- 退会時に投稿を全て非公開に変更

・お気に入り一覧で、常にログイン中ユーザのお気に入りが表示されてしまうのを修正