### PR TITLE
Support responsive admins

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,11 @@
 module ApplicationHelper
+  #ページごとにタイトルを変更する
+  def full_title(page_title = '')
+    base_title = "Shareversary"
+      if page_title.empty? #タイトルが設定されていない場合
+        base_title #サイト名だけ表示
+      else
+        "#{ page_title } / #{ base_title }"
+      end
+  end
 end

--- a/app/views/admin/genres/edit.html.erb
+++ b/app/views/admin/genres/edit.html.erb
@@ -1,6 +1,8 @@
+<% provide(:title, "タグの編集") %>
+
 <div class="container">
   <div class="row">
-    <h4 class="red-border bg-light m-4">ジャンル編集</h4>
+    <h4 class="red-border bg-light m-4">タグ編集</h4>
   </div>
   <div class="row mt-4">
     <div class='col'>
@@ -8,7 +10,7 @@
       <table>
         <tbody>
           <tr>
-            <td class="text-dark" width="100">ジャンル名</td>
+            <td class="text-dark" width="100">タグ名</td>
             <td width="200"><%= f.text_field :name %></td>
             <td><%= f.submit "変更を保存", class:"btn btn-success" %></td>
           </tr>

--- a/app/views/admin/genres/index.html.erb
+++ b/app/views/admin/genres/index.html.erb
@@ -35,6 +35,7 @@
                         <tr>
                           <td><%= genre.name %></td>
                           <td><%= link_to "編集", edit_admin_genre_path(genre.id), class: "btn btn-sm btn-success" %></td>
+                          <td><%= link_to "検索", genre_index_path(genre.id), class: "btn btn-sm btn-secondary" %></td>
                           <td><%= link_to "削除", admin_genre_path(genre.id), method: :delete, class: "btn btn-sm btn-danger" %></td>
                         </tr>
                     <% end %>

--- a/app/views/admin/genres/index.html.erb
+++ b/app/views/admin/genres/index.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "タグ一覧") %>
+
 <div class="container">
     <div class="row">
         <h4 class="red-border bg-light m-4">タグ一覧</h4>

--- a/app/views/admin/posts/index.html.erb
+++ b/app/views/admin/posts/index.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "記念日一覧") %>
+
 <div class="container m-2 mx-auto">
  <div class="row">
   <h2>記念日一覧</h2>

--- a/app/views/admin/posts/show.html.erb
+++ b/app/views/admin/posts/show.html.erb
@@ -6,19 +6,12 @@
 
      <div class="col-md-3">
       <h4>記念日を作った人</h4>
-      <div class="m-2 text-center"><%= attachment_image_tag @post.user, :profile_image, :fill, 100, 100, fallback: "no_image.png", size: '100x100', class: "rounded border" %></div>
-       <table class="table">
-        <tbody>
-          <tr><th><%= @post.user.user_name %></th></tr>
-          <tr><th><%= @post.user.introduction%></th></tr>
-            <tr><th><%= @post.user.email%></th></tr>
-            <tr><th><%= link_to "ユーザー編集", edit_admin_user_path(@post.user) %></th></tr>
-          <tr><th><%= link_to "いいねした記念日", favorite_path(@post.user) %></th></tr>
-        </tbody>
-       </table>
+      <div class="border border-secondary rounded mb-2" style="background-color:#f4f4f4">
+          <%= render 'admin/users/info', user: @post.user %>
+        </div>
      </div>
 
-     <div class="col-md-9">
+     <div class="col-md-9 order-first order-md-last">
        <h3>記念日</h3>
         <table class="table table-inverse">
           <thead class="text-center">

--- a/app/views/admin/posts/show.html.erb
+++ b/app/views/admin/posts/show.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "#{@post.user.user_name}さんの#{@post.title}") %>
+
 <div class="container m-2 mx-auto">
   <h2>記念日詳細</h2>
     <div class="row">

--- a/app/views/admin/posts/show.html.erb
+++ b/app/views/admin/posts/show.html.erb
@@ -39,10 +39,24 @@
         <%# いいね数表示 %>
         <i class="fas fa-star fav-btn"></i><%= @post.favorites.count %>
 
-          <%= link_to "編集", edit_admin_post_path %>
-          <%= link_to "削除", post_path(@post), method: :delete, "data-confirm" => "本当に削除しますか？" %>
+        <%# ジャンル機能 %>
+          <% @post.genres.each do |genre| %>
+            <span class="border rounded p-1">
+              <%= link_to genre_index_path(genre.id) do %>
+                <i class="fas fa-tag text-black-50"><%= genre.name %></i>
+              <% end %>
+            </span>
+          <% end %>
 
-        <%= link_to "一覧に戻る", admin_posts_path %>
+
+
+        <div class="mx-1 ml-auto">
+          <%= link_to "編集", edit_admin_post_path %>
+            |
+          <%= link_to "削除", post_path(@post), method: :delete, "data-confirm" => "本当に削除しますか？"  %>
+            |
+          <%= link_to "一覧に戻る", admin_posts_path %>
+        </div>
 
      </div>
 

--- a/app/views/admin/users/_info.html.erb
+++ b/app/views/admin/users/_info.html.erb
@@ -1,0 +1,28 @@
+<div class="m-2 text-center">
+  <%= attachment_image_tag user, :profile_image, :fill, 100, 100, fallback: "no_image.png", size: '100x100', class: "rounded border", style: "background-color:#ffffff" %>
+</div>
+<table class="table">
+  <tbody>
+    <tr>
+      <th>
+        <%= user.user_name %></br>
+        <span style="font-size:10px;"><%= user.introduction %></span>
+      </th>
+    </tr>
+    <tr>
+      <th>ステータス：
+        <% if user.is_active %>
+          <span class="text-success">有効</span>
+        <% else %>
+          <span class="text-secondary">退会済み</span>
+        <% end %>
+      </th>
+    </tr>
+    <tr><th><%= user.email%></th></tr>
+    <tr><th><%= link_to "ユーザー編集", edit_user_path(user) %></th></tr>
+    <tr><th><%= link_to "いいねした記念日", favorite_path(user) %></th></tr>
+  </tbody>
+</table>
+
+<%# 貼り付け用 %>
+<%# render 'admin/users/info', user: @user %>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "#{@user.user_name}さんを編集する") %>
+
 <div class="container-fluid">
   <div class="row">
     <div class="col-sm-12 col-md-12 col-lg-5 px-5 px-sm-0 mx-auto">

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "ユーザー一覧") %>
+
 <div class="container">
   <h2>ユーザー一覧</h2>
   <div class="row">

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -5,23 +5,9 @@
     <div class="row">
 
      <div class="col-md-3">
-      <div class="m-2 text-center"><%= attachment_image_tag @user, :profile_image, :fill, 100, 100, fallback: "no_image.png", size: '100x100', class: "rounded border" %></div>
-       <table class="table">
-        <tbody>
-          <tr>
-            <th><%= @user.user_name %></th>
-            <% if @user.is_active == true %>
-              <div class="text-success">有効</div>
-            <% else %>
-              <div class="text-secondary">退会済み</div>
-            <% end %>
-          </tr>
-          <tr><th><%= @user.introduction%></th></tr>
-          <tr><th><%= @user.email%></th></tr>
-          <tr><th><%= link_to "ユーザーの編集", edit_admin_user_path(@user) %></th></tr>
-          <tr><th><%= link_to "いいねした記念日", favorite_path(@user) %></th></tr>
-        </tbody>
-       </table>
+      <div class="border border-secondary rounded mb-2" style="background-color:#f4f4f4">
+          <%= render 'admin/users/info', user: @user %>
+        </div>
      </div>
 
      <div class="col-md-9">

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "#{@user.user_name}さん") %>
+
 <h2 class="offset-1">ユーザ詳細</h2>
 <div class="container m-2 mx-auto">
     <div class="row">

--- a/app/views/genre_relations/index.html.erb
+++ b/app/views/genre_relations/index.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "「#{@genre.name}」の記念日一覧") %>
+
 <div class="container m-2 mx-auto">
  <div class="row">
   <h2>「<%= @genre.name %>」タグの記念日一覧</h2>

--- a/app/views/genre_relations/index.html.erb
+++ b/app/views/genre_relations/index.html.erb
@@ -7,7 +7,11 @@
 
  <div class="row">
     <% if @posts.exists? %>
-      <%= render 'public/posts/table', posts: @posts %>
+      <% if admin_signed_in? %>
+        <%= render 'admin/posts/table', posts: @posts %>
+      <% else %>
+        <%= render 'public/posts/table', posts: @posts %>
+      <% end %>
     <% else %>
       <span>該当する投稿はありません。
       記念日を<%= link_to "投稿", new_post_path %>してみませんか？</span>

--- a/app/views/homes/home.html.erb
+++ b/app/views/homes/home.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "ホーム") %>
+
 <div class="container-fluid">
   <h3>ホーム</h3>
     <%= flash[:notice] %>

--- a/app/views/homes/landing.html.erb
+++ b/app/views/homes/landing.html.erb
@@ -31,7 +31,7 @@
     </div>
 
 
-    <div class="col-sm-4 border-left d-flex flex-column align-items-center justify-content-center" style="background-color:#f5f5f5">
+    <div class="col-md-4 border-left d-flex flex-column align-items-center justify-content-center" style="background-color:#f5f5f5">
       <div class="m-3">
         <h3>記念日で、</br>ちょっと違った毎日を。</h3>
       </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -2,7 +2,7 @@
   <% if admin_signed_in? %>
     <%# 管理者ログイン時にヘッダー色の変更 %>
     <nav class="navbar navbar-expand-md navbar-dark" style="background-color:#cc8fa1">
-      <a class="navbar-brand" href = "/"><span>Shareversary 管理者</span></a>
+      <a class="navbar-brand" href = "/home"><span>Shareversary 管理者</span></a>
   <% else %>
     <nav class="navbar navbar-expand-md navbar-dark" style="background-color:#8fccba">
       <a class="navbar-brand" href = "/"><span>Shareversary</span></a>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -17,6 +17,11 @@
         <ul class="navbar-nav ml-auto">
 
         <% if admin_signed_in? %>
+          <% if current_page?(root_path) %>
+            <li class="nav-item"><%= link_to "トップ", home_path, class: 'fas fa-home nav-link text-light' %></li>
+          <% else %>
+            <li class="nav-item"><%= link_to "ランディングページ", root_path, class: 'fas fa-home nav-link text-light' %></li>
+          <% end %>
             <li class="nav-item"><%= link_to " 記念日をつくる", new_post_path, class: 'fas fa-calendar-plus nav-link text-light' %></li>
             <li class="nav-item"><%= link_to " 記念日一覧", admin_posts_path, class: 'fas fa-calendar-alt nav-link text-light' %></li>
             <li class="nav-item"><%= link_to " ユーザー一覧", admin_users_path, class: 'fas fa-users nav-link text-light' %></li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Shareversary</title>
+    <title><%= full_title(yield(:title)) %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 

--- a/app/views/public/favorites/show.html.erb
+++ b/app/views/public/favorites/show.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "#{@user.user_name}さんのいいね") %>
+
 <div class="container m-2 mx-auto">
  <div class="row">
   <h2><%= @user.user_name %>さんがいいねした記念日</h2>

--- a/app/views/public/posts/date_index.html.erb
+++ b/app/views/public/posts/date_index.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "#{@date}の記念日一覧") %>
+
 <div class="container m-2 mx-auto">
   <div class="row">
       <h2><%= @date %>の記念日一覧</h2>

--- a/app/views/public/posts/edit.html.erb
+++ b/app/views/public/posts/edit.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "記念日の編集") %>
+
 <div class="container">
   <div class="row">
     <div class="col-8 col-lg-6 px-md-5 mx-auto">

--- a/app/views/public/posts/index.html.erb
+++ b/app/views/public/posts/index.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "記念日一覧") %>
+
 <div class="container m-2 mx-auto">
   <div class="row">
     <h2>記念日一覧</h2>

--- a/app/views/public/posts/new.html.erb
+++ b/app/views/public/posts/new.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "記念日をつくる") %>
+
 <div class="container">
   <div class="row">
     <div class="col-8 col-lg-5 px-md-5 mx-auto">

--- a/app/views/public/posts/show.html.erb
+++ b/app/views/public/posts/show.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "#{@post.user.user_name}さんの#{@post.title}") %>
+
 <div class="container m-2 mx-auto">
   <h2>記念日詳細</h2>
     <div class="row">

--- a/app/views/public/users/edit.html.erb
+++ b/app/views/public/users/edit.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "プロフィール編集") %>
+
 <div class="container-fluid">
   <div class="row">
     <div class="col-6 px-2 mx-auto">

--- a/app/views/public/users/show.html.erb
+++ b/app/views/public/users/show.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "#{@user.user_name}さん") %>
+
 <h2 class="offset-1">ユーザ詳細</h2>
 <div class="container m-2 mx-auto">
     <div class="row">


### PR DESCRIPTION
・管理者側のVIewページを編集
　- エンドユーザ側で設定したレスポンシブを管理者側にも反映
　- エンドユーザとレイアウトが異なっていた部分を修正

・（エンド/管理者）各ページごとにタイトル名を変更される機能を追加
　→それっぽさの向上

・管理者側 タグ一覧画面にジャンル一覧検索ボタンを追加