### PR TITLE
Fix date search

### DIFF
--- a/app/controllers/public/posts_controller.rb
+++ b/app/controllers/public/posts_controller.rb
@@ -6,10 +6,10 @@ class Public::PostsController < ApplicationController
   end
 
   def date_index #特定日の全投稿一覧
-    @date = params[:date].gsub(/-/,'') #日時計算用にハイフンを除外
-    @tomorrow = (@date.to_i + 1).to_s
-    @yesterday = (@date.to_i - 1).to_s
-    @posts = Post.where(date: @date).where("(is_private = ?) OR (user_id = ?)", false, current_user) #日付→公開ポストの順で抽出
+    @date = params[:date].to_date
+    @tomorrow = @date.tomorrow
+    @yesterday = @date.yesterday
+    @posts = Post.where(date: @date.to_s).where("(is_private = ?) OR (user_id = ?)", false, current_user) #日付→公開ポストの順で抽出
   end
 
   def create

--- a/app/controllers/public/posts_controller.rb
+++ b/app/controllers/public/posts_controller.rb
@@ -6,10 +6,11 @@ class Public::PostsController < ApplicationController
   end
 
   def date_index #特定日の全投稿一覧
-    @date = params[:date].to_date
+    @date = params[:date].to_date #パラメータをDate型に変換
     @tomorrow = @date.tomorrow
     @yesterday = @date.yesterday
-    @posts = Post.where(date: @date.to_s).where("(is_private = ?) OR (user_id = ?)", false, current_user) #日付→公開ポストの順で抽出
+    @posts = Post.where(date: @date.to_s).where("(is_private = ?) OR (user_id = ?)", false, current_user)
+    #日付→公開ポストの順で抽出、検索のため@dateをstringに変換
   end
 
   def create

--- a/app/views/public/posts/date_index.html.erb
+++ b/app/views/public/posts/date_index.html.erb
@@ -1,4 +1,4 @@
-<% provide(:title, "#{@date}の記念日一覧") %>
+<% provide(:title, "#{@date.to_s}の記念日一覧") %>
 
 <div class="container m-2 mx-auto">
   <div class="row">

--- a/app/views/public/posts/date_index.html.erb
+++ b/app/views/public/posts/date_index.html.erb
@@ -1,8 +1,8 @@
-<% provide(:title, "#{@date.to_s}の記念日一覧") %>
+<% provide(:title, "#{@date.strftime("%m月%d日")}の記念日一覧") %>
 
 <div class="container m-2 mx-auto">
   <div class="row">
-      <h2><%= @date %>の記念日一覧</h2>
+      <h2><%= @date.strftime("%m月%d日") %>の記念日一覧</h2>
       <div class="m-2 ml-auto">
         <%= link_to "< 前の日", date_index_path(@yesterday) %> |
         <%= link_to "次の日 >", date_index_path(@tomorrow) %>


### PR DESCRIPTION
・日付ごとの投稿一覧で、一部日付における次の日/前の日が正しく機能しない不具合を修正
（2021-10-31→2021-10-32→...→2021-10-99→2021-11-00）
・画面の表示される日付を(%m %d)に変更

今後の課題：他年の同じ日に作られた記念日も同一ページ・違うテーブルで表示させたい